### PR TITLE
fix dynamic factories

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![CI](https://github.com/pyapp-kit/griffe-fieldz/actions/workflows/ci.yml/badge.svg)](https://github.com/pyapp-kit/griffe-fieldz/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/pyapp-kit/griffe-fieldz/branch/main/graph/badge.svg)](https://codecov.io/gh/pyapp-kit/griffe-fieldz)
 
-Griffe extension adding support for data-class like things (pydantic, attrs,
+Griffe extension adding support for dataclass-like things (pydantic, attrs,
 etc...). This extension will inject the fields of the data-class into the
 documentation, preventing you from duplicating field metadata in your
 docstrings.


### PR DESCRIPTION
fixes #14 in multiple ways:

- avoids `TypeError: MyClass._default_my_attribute() missing 1 required positional argument: 'self'` by not calling default_factories that require arguments.
- *still* calls default factories in a try/catch just in case
- in the case of default_factories that cannot be evaluated... returns the string `<dynamic>` for the "default" field.
- This PR also does a better job of merging partial info between an existing docstring, and a dataclass field (so, for example, if you put the name, type and description in the docstring, but only had the default value in the field definition, it would successfully merge them.  Priority goes to the docstring 