### PR TITLE
Depend on griffelib instead of griffe

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ classifiers = [
     "Topic :: Utilities",
     "Typing :: Typed",
 ]
-dependencies = ["griffe>=1.0", "fieldz>=0.1.0"]
+dependencies = ["griffelib>=2.0", "fieldz>=0.1.0"]
 
 
 # https://peps.python.org/pep-0621/#dependencies-optional-dependencies


### PR DESCRIPTION
Hey, Griffe author here, I've recently released v2, which decouples the CLI from the library. Downstream projects can now depend on `griffelib` instead of `griffe` to avoid pulling in CLI dependencies such as `colorama`.

Bumping to 2 might not be desirable here, so feel free to close :slightly_smiling_face: 

Just note that since `griffe` v1 and `griffelib` v2 distributions both provides a `griffe` package, this can cause installation conflicts. I have updated all the official Griffe extensions to depend on `griffelib` to avoid that :slightly_smiling_face: 